### PR TITLE
Change output file in predict.py remove argparser in post_process.py

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Fly by CNN
+# Fly by CNN
 
 ## What is it?
 Fly by CNN is a C++ code that takes a 3D mesh and create 2D images of this one following the unit sphere and the number of subdivisions associated. The 2D images created contained the mesh features and labels.

--- a/src/py/post_process.py
+++ b/src/py/post_process.py
@@ -2,10 +2,10 @@ import vtk
 import numpy as np
 import argparse
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--mesh', help='Insert mesh path')
-parser.add_argument('--out', help='Insert output path+name')
-arg = parser.parse_args()
+# parser = argparse.ArgumentParser()
+# parser.add_argument('--mesh', help='Insert mesh path')
+# parser.add_argument('--out', help='Insert output path+name')
+# arg = parser.parse_args()
 
 def ChangeLabel(vtkdata, label_array, label2change, change):
 	# Set all the label 'label2change' in 'change'
@@ -234,10 +234,10 @@ def Label_Teeth(vtkdata, label_array):
 	return vtkdata
 
 
-mesh, mesh_label = ReadFile(arg.mesh)
-mesh, mesh_label = Post_processing(mesh)
-mesh = Label_Teeth(mesh, mesh_label)
-Write(mesh, arg.out)
+# mesh, mesh_label = ReadFile(arg.mesh)
+# mesh, mesh_label = Post_processing(mesh)
+# mesh = Label_Teeth(mesh, mesh_label)
+# Write(mesh, arg.out)
 
 # python3 post_process.py --mesh /Users/mdumont/Downloads/scan2_test.vtk --out /Users/mdumont/Desktop/DCBIA-projects/Output/scan2_PP.vtk
 

--- a/src/py/predict.py
+++ b/src/py/predict.py
@@ -76,7 +76,7 @@ parser.add_argument('--numberOfSubdivisions', type=int, help='Number of subdivis
 parser.add_argument('--sphereRadius', type=float, help='Radius of the surrounding sphere', default=1.1)
 parser.add_argument('--planeResolution', type=int, help='Radius of the surrounding sphere', default=512)
 parser.add_argument('--planeSpacing', type=float, help='Spacing of the plane', default=1.0)
-parser.add_argument('--out', type=str, help='Output model with labels', default="out.vtk")
+# parser.add_argument('--out', type=str, help='Output model with labels', default="out.vtk")
 
 args = parser.parse_args()
 
@@ -86,7 +86,9 @@ planeResolution = args.planeResolution
 savedModelPath = args.model
 sphereRadius = args.sphereRadius
 numberOfSubdivisions = args.numberOfSubdivisions
-outfilename = args.out
+[name, ext] = os.path.splitext(inputSurface)
+name = name + '_seg'
+outfilename = name + ext
 
 print("planeSpacing", planeSpacing)
 print("planeResolution", planeResolution)
@@ -191,7 +193,7 @@ with tf.Session() as sess:
 			}
 		)
 
-    prediction = np.reshape(np.array(prediction[0]), [planeResolution*planeResolution])
+		prediction = np.reshape(np.array(prediction[0]), [planeResolution*planeResolution])
     
 		for index in range(planeResolution*planeResolution):
 			pointId = pointid_array[index]


### PR DESCRIPTION
Post_process argparser did some errors when trying to run predict.py.
Bad indentation in predict.py
Fix the output file value in order to make it simpler when computing several mesh in the website. Now the output name is [name_of_scan]_seg.vtk